### PR TITLE
Include old option name in docs

### DIFF
--- a/biblatex-science.tex
+++ b/biblatex-science.tex
@@ -51,7 +51,7 @@ of example citations.
 The style introduces one new bibliography string, \texttt{presentedat}:
 the text \enquote{presented at the} when printing conference papers.
 This may be localized in the usual way. The style also introduces one
-new Boolean load-time option, \texttt{articletitle}. When this is
+new Boolean load-time option, \texttt{articletitle} (\textt{article-title} before v1.2). When this is
 set \texttt{true}, the titles of journal articles are printed: the
 journal \emph{Science} does this for the on-line edition but not in
 print.


### PR DESCRIPTION
Overleaf currently uses v1.1, so "articletitle" throws a keyval error.