### PR TITLE
adding journal title and removing urls to conform with Science

### DIFF
--- a/science.bbx
+++ b/science.bbx
@@ -21,7 +21,7 @@
 
 % Alter settings that carry through from biblatex
 \ExecuteBibliographyOptions{
-  articletitle  = false ,
+  articletitle  = true  ,
   doi           = false ,
   giveninits            ,
   maxnames      = 5     ,
@@ -236,9 +236,9 @@
   \iftoggle{bbx:isbn}
     {\printfield{issn}}
     {}%
-  \newunit\newblock
-  \usebibmacro{doi+eprint+url}%
-  \setunit{\addspace}\newblock
+ % \newunit\newblock
+ % \usebibmacro{doi+eprint+url}%
+ % \setunit{\addspace}\newblock
   \iffieldundef{year}
     {\printfield{howpublished}}
     {\usebibmacro{issue+date}}%
@@ -283,8 +283,8 @@
   \iftoggle{bbx:isbn}
     {\printfield{isbn}}
     {}%
-  \newunit\newblock
-  \usebibmacro{doi+eprint+url}%
+ % \newunit\newblock
+ % \usebibmacro{doi+eprint+url}%
   \newunit\newblock
   \usebibmacro{addendum+pubstate}%
   \setunit{\bibpagerefpunct}\newblock
@@ -451,8 +451,8 @@
   \iftoggle{bbx:isbn}
     {\printfield{isbn}}
     {}%
-  \newunit\newblock
-  \usebibmacro{doi+eprint+url}%
+%  \newunit\newblock
+%  \usebibmacro{doi+eprint+url}%
   \newunit\newblock
   \usebibmacro{addendum+pubstate}%
   \setunit{\bibpagerefpunct}\newblock


### PR DESCRIPTION
Science now requires that journal articles contain titles: https://www.science.org/content/page/instructions-preparing-initial-manuscript , so I edited the science.bbx to print these. 

I also removed urls and DOIs for books and journal articles, since these seem to be lacking in Science's format (though they are not clear on this point). 